### PR TITLE
Make ClassUtils.getRealClass more generic

### DIFF
--- a/src/main/java/de/cronn/reflection/util/ClassUtils.java
+++ b/src/main/java/de/cronn/reflection/util/ClassUtils.java
@@ -28,13 +28,13 @@ public final class ClassUtils {
 	private ClassUtils() {
 	}
 
-	public static <T> Class<T> getRealClass(T object) {
+	public static <T> Class<? extends T> getRealClass(T object) {
 		@SuppressWarnings("unchecked")
 		Class<T> entityClass = (Class<T>) object.getClass();
 		return getRealClass(entityClass);
 	}
 
-	private static <T> Class<T> getRealClass(Class<T> clazz) {
+	private static <T> Class<? extends T> getRealClass(Class<T> clazz) {
 		if (isProxyClass(clazz)) {
 			if (Proxy.isProxyClass(clazz)) {
 				Class<?>[] interfaces = clazz.getInterfaces();


### PR DESCRIPTION
Change makes code compile 
```java
	static class A{}
	static class B extends A{}
	public static void main(String[] args) {
		A object = new B();
		Assert.isTrue(ClassUtils.getRealClass(object) == B.class);
	}
```