### PR TITLE
ImmutableProxy: Add support for UUID

### DIFF
--- a/src/main/java/de/cronn/reflection/util/immutable/ImmutableProxy.java
+++ b/src/main/java/de/cronn/reflection/util/immutable/ImmutableProxy.java
@@ -9,6 +9,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.objenesis.ObjenesisHelper;
@@ -89,6 +90,8 @@ public final class ImmutableProxy {
 		} else if (value instanceof Temporal) {
 			return true;
 		} else if (value instanceof TemporalAmount) {
+			return true;
+		} else if (value instanceof UUID) {
 			return true;
 		} else if (isEnumValue(value)) {
 			return true;

--- a/src/test/java/de/cronn/reflection/util/immutable/ImmutableProxyTest.java
+++ b/src/test/java/de/cronn/reflection/util/immutable/ImmutableProxyTest.java
@@ -17,6 +17,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.CompletionService;
 import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
@@ -83,6 +84,7 @@ public class ImmutableProxyTest {
 	public void testImmutableProxy_TestEntity() throws Exception {
 		TestEntity original = new TestEntity(123);
 		original.setSomeInstant(Instant.parse("2018-07-12T13:38:56Z"));
+		original.setSomeUuid(UUID.fromString("28e93b24-7252-43d8-a223-ca0b3270bd7f"));
 		original.setSomeList(Arrays.asList(new OtherTestEntity("one"), new OtherTestEntity("other")));
 		original.setSomeSet(new LinkedHashSet<>(Arrays.asList("a", "b", "c")));
 
@@ -117,6 +119,7 @@ public class ImmutableProxyTest {
 
 		assertThat(immutableProxy.asMyself()).isInstanceOf(Immutable.class);
 		assertThat(immutableProxy.asMyself().getSomeInstant()).isSameAs(original.getSomeInstant());
+		assertThat(immutableProxy.asMyself().getSomeUuid()).isSameAs(original.getSomeUuid());
 	}
 
 	@Test

--- a/src/test/java/de/cronn/reflection/util/testclasses/TestEntity.java
+++ b/src/test/java/de/cronn/reflection/util/testclasses/TestEntity.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.UUID;
 
 import javax.annotation.Nullable;
 import javax.validation.constraints.Size;
@@ -31,6 +32,8 @@ public class TestEntity extends AbstractClassWithAnnotatedMethods implements Int
 	private String fieldWithAnnotationOnSetter;
 
 	private Instant someInstant;
+
+	private UUID someUuid;
 
 	private OtherTestEntity otherTestEntity;
 
@@ -102,6 +105,14 @@ public class TestEntity extends AbstractClassWithAnnotatedMethods implements Int
 
 	public void setSomeInstant(Instant someInstant) {
 		this.someInstant = someInstant;
+	}
+
+	public UUID getSomeUuid() {
+		return someUuid;
+	}
+
+	public void setSomeUuid(UUID someUuid) {
+		this.someUuid = someUuid;
 	}
 
 	public OtherTestEntity getOtherTestEntity() {


### PR DESCRIPTION
UUID class is _immutable_; from its javadoc:

> A class that represents an immutable universally unique identifier (UUID).

ByteBuddy throws exception when tries to subclass it:
```
Cannot subclass primitive, array or final types: class java.util.UUID
java.lang.IllegalArgumentException: Cannot subclass primitive, array or final types: class java.util.UUID
	at net.bytebuddy.ByteBuddy.subclass(ByteBuddy.java:406)
```